### PR TITLE
Addressed a few issues in #49

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -11,6 +11,12 @@ record SearchVariantsRequest {
   // Only return variants which have exactly this name.
   union { null, string } variantName = null;
 
+  // If true, SearchVariantsResponse::variants[j].calls[i].callSampleId will
+  // be set for all j and i. If false, this field will be absent and
+  // SearchVariantsResponse::variants[j].calls[i] is a call for
+  // SearchVariantsRequest::callSampleIds[i].
+  boolean sparseResponse = false;
+
   // Only return variant calls which belong to callsamples which have exactly
   // these names. Leaving this blank returns all variant calls.
   // At most one of callSampleNames or callSampleIds should be provided.
@@ -43,8 +49,7 @@ record SearchVariantsRequest {
 
 // This is the response from POST /variants/search
 record SearchVariantsResponse {
-  // The list of matching Variants. For each variant, GAVariant::calls[i]
-  // is a call for sample SearchVariantsRequest::callSampleIds[i].
+  // The list of matching Variants.
   array<GAVariant> variants = [];
 
   // The continuation token, which is used to page through large result sets.

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -43,7 +43,8 @@ record SearchVariantsRequest {
 
 // This is the response from POST /variants/search
 record SearchVariantsResponse {
-  // The list of matching Variants.
+  // The list of matching Variants. For each variant, GAVariant::calls[i]
+  // is a call for sample SearchVariantsRequest::callSampleIds[i].
   array<GAVariant> variants = [];
 
   // The continuation token, which is used to page through large result sets.

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -10,20 +10,20 @@ record GAVariantSet {
   // The variant set ID.
   string id;
   
-  // The ID of the dataset this variant set belongs to.
-  string datasetId;
-  
-  // TODO: Add reference sequence ID information once resolved.
+  // The ID of GAReferenceSequenceSet used to call the variants
+  string referenceSequenceSetId;
   
   // IDs of the call samples that belong to this variant set.
-  // TODO: This field is under ongoing discussion and needs to be resolved
-  // before this API is final.
   array<string> callSampleIds = [];
   
   // Names of the call samples that belong to this variant set.
-  // TODO: This field is under ongoing discussion and needs to be resolved
-  // before this API is final.
+  // Arrays callSampleIds[] and callSampleNames[] are required to have the same
+  // length as GAVariant::calls[] below. GAVariant::calls[i] is always the call
+  // for callSampleIds[i].
   array<string> callSampleNames = [];
+
+  // The date this callsample was created in milliseconds from the epoch.
+  union { null, long } created = null;
 }
 
 // A CallSample is a collection of Variant Calls for a particular sample. 
@@ -41,8 +41,8 @@ record GACallSample {
   // The IDs of the variant sets this callsample has calls in.
   array<string> variantSetIds = [];
 
-  // The date this callsample was created in milliseconds from the epoch.
-  union { null, long } created = null;
+  // List of read groups from which the calls for this sample are made.
+  array<string> readGroupIds = [];
 
   // A map of additional callsample information.
   array<GAKeyValue> info = [];
@@ -54,16 +54,6 @@ record GACallSample {
 // a SNP named rs1234 in a callsample with the name NA12345.
 // TODO: Nest this object under GAVariant
 record GACall {
-
-  // The ID of the callsample this variant call belongs to.
-  // TODO: This field is under ongoing discussion and needs to be resolved
-  // before this API is final.
-  string callSampleId;
-
-  // The name of the callsample this variant call belongs to.
-  // TODO: This field is under ongoing discussion and needs to be resolved
-  // before this API is final.
-  union { null, string } callSampleName = null;
 
   // The genotype of this variant call. Each value represents either the value
   // of the referenceBases field or is a 1-based index into alternateBases.
@@ -103,9 +93,6 @@ record GAVariant {
   // Names for the variant, for example a RefSNP ID.
   array<string> names = [];
 
-  // The date this variant was created in milliseconds from the epoch.
-  union { null, long } created = null;
-
   // The reference sequence on which this variant occurs. (e.g. 'chr20' or 'X')
   string referenceSequenceName;
 
@@ -113,8 +100,7 @@ record GAVariant {
   // This corresponds to the first base of the string of reference bases.
   long position;
 
-  // The reference bases for this variant. They start at the given
-  // position.
+  // The reference bases for this variant. They start at the given position.
   string referenceBases;
 
   // The bases that appear instead of the reference bases.
@@ -124,7 +110,8 @@ record GAVariant {
   array<GAKeyValue> info = [];
 
   // The variant calls for this particular variant. Each one represents the
-  // determination of genotype with respect to this variant.
+  // determination of genotype with respect to this variant. The length of
+  // this array is identical to the length of GAVariantSet::callSampleIds[].
   array<GACall> calls = [];
 }
 

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -17,9 +17,6 @@ record GAVariantSet {
   array<string> callSampleIds = [];
   
   // Names of the call samples that belong to this variant set.
-  // Arrays callSampleIds[] and callSampleNames[] are required to have the same
-  // length as GAVariant::calls[] below. GAVariant::calls[i] is always the call
-  // for callSampleIds[i].
   array<string> callSampleNames = [];
 
   // The date this callsample was created in milliseconds from the epoch.
@@ -54,6 +51,13 @@ record GACallSample {
 // a SNP named rs1234 in a callsample with the name NA12345.
 // TODO: Nest this object under GAVariant
 record GACall {
+
+  // The ID of the callsample this variant call belongs to. See the comment on
+  // GAVariant::calls[] about more details.
+  union { null, string } callSampleId = null;
+
+  // The name of the callsample this variant call belongs to.
+  union { null, string } callSampleName = null;
 
   // The genotype of this variant call. Each value represents either the value
   // of the referenceBases field or is a 1-based index into alternateBases.
@@ -110,8 +114,9 @@ record GAVariant {
   array<GAKeyValue> info = [];
 
   // The variant calls for this particular variant. Each one represents the
-  // determination of genotype with respect to this variant. The length of
-  // this array is identical to the length of GAVariantSet::callSampleIds[].
+  // determination of genotype with respect to this variant. If
+  // calls[i].callSampleId is absent, calls[i] is a call for
+  // GAVariantSet::callSampleId[i].
   array<GACall> calls = [];
 }
 


### PR DESCRIPTION
Some of the following changes are related to how VCFs are made. In the current practice, we call variants by jointly considering all samples at the same time. Broad is advocating single-sample calling, but this pipeline requires gVCF (different from the 1000g VCFs) and still merges all samples at the same time in the end. VariantSets can hardly be split or merged without hurting self-consistency and accuracy. In particular, we are not calling each sample independently and then iteratively merging the single-sample calls to the an existing VCF.

Summary of changes:
1. Removed GAVariantSet::datasetId. A VariantSet is frequently made from two or more datasets defined in reads.avdl. For example, we may make a call set for 1000g and PGP. In this case, datasetId cannot be set.
2. Removed GACall::callSampleId and GACall::callSampleName. Accordingly, clarify that the ordering of GAVariant::calls[] is defined by SearchVariantsResponse::callSampleId[], or by GAVariantSet::callSampleId[]. Sparse VCFs, which are widely discouraged, can still be represented by using missing values.
3. Moved GAVariant::created and GACallSample::created to GAVariantSet. The whole GAVariantSet is made at the same time.
4. Added GAVariantSet::referenceSequenceSetId, as #66 is to be merged soon.
5. Added GACallSample::readGroupIds[]. This links a callSample to the read data.
