### PR TITLE
Move fragment data into the fragment object (WIP)

### DIFF
--- a/src/main/resources/avro/readmethods.avdl
+++ b/src/main/resources/avro/readmethods.avdl
@@ -79,6 +79,84 @@ SearchReadsResponse searchReads(
   /** This request maps to the body of `POST /reads/search` as JSON. */
   SearchReadsRequest request) throws GAException;
 
+/******************  /fragments/search  *********************/
+/**
+This request maps to the body of `POST /fragments/search` as JSON.
+
+If a reference is specified, all queried `ReadGroup`s must be aligned
+to `ReferenceSet`s containing that same `Reference`. If no reference is
+specified, all `ReadGroup`s must be aligned to the same `ReferenceSet`.
+*/
+record SearchFragmentsRequest {
+  /**
+  If nonempty, restrict this query to `Fragments`s within the given
+  `ReadGroup`s.
+  */
+  array<string> readGroupIds = [];
+
+  /**
+  The reference to query. Leaving blank returns results from all
+  references
+  */
+  union { null, string } referenceId = null;
+
+  /**
+  The start position (0-based) of this query.
+  All reads in a fragment must be contained in the [start-end) interval to be
+  returned
+  If a reference is specified, this defaults to 0.
+  Genomic positions are non-negative integers less than reference length.
+  Requests spanning the join of circular genomes are represented as
+  two requests one on each side of the join (position 0).
+  */
+  union { null, long } start = null;
+
+  /**
+  The end position (0-based, exclusive) of this query.
+  All reads in a fragment must be contained in the [start-end) interval to be
+  returned
+  If a reference is specified, this defaults to the
+  reference's length.
+  */
+  union { null, long } end = null;
+
+  /**
+  Specifies the maximum number of results to return in a single page.
+  If unspecified, a system default will be used.
+  */
+  union { null, int } pageSize = null;
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  To get the next page of results, set this parameter to the value of
+  `nextPageToken` from the previous response.
+  */
+  union { null, string } pageToken = null;
+}
+
+/** This is the response from `POST /fragments/search` expressed as JSON. */
+record SearchFragmentsResponse {
+  /** The list of matching Fragments. */
+  array<org.ga4gh.models.Fragments> fragments = [];
+
+  /**
+  The continuation token, which is used to page through large result sets.
+  Provide this value in a subsequent request to return the next page of
+  results. This field will be empty if there aren't any additional results.
+  */
+  union { null, string } nextPageToken = null;
+}
+
+/**
+Gets a list of `Fragment`s matching the search criteria.
+
+`POST /fragments/search` must accept a JSON version of `SearchFragmentsRequest` as
+the post body and will return a JSON version of `SearchFragmentsResponse`.
+*/
+SearchFragmentsResponse searchFragments(
+  /** This request maps to the body of `POST /fragments/search` as JSON. */
+  SearchFragmentsRequest request) throws GAException;
+
 /******************  /readgroupsets/search  *********************/
 /** This request maps to the body of `POST /readgroupsets/search` as JSON. */
 record SearchReadGroupSetsRequest {

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -3,12 +3,12 @@
 /**
 This file defines the objects used to represent a hierarchy of reads and alignments:
 
-ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear/graph alignment
+ReadGroupSet >--< ReadGroup --< Fragment --< read --< alignment --< linear/graph alignment
 
 * A ReadGroupSet is a logical collection of ReadGroup's.
 * A ReadGroup is all the data that's processed the same way by the sequencer.
  There are typically 1-10 ReadGroup's in a ReadGroupSet.
-* A *fragment* is a single stretch of a DNA molecule. There are typically
+* A Fragment is a single stretch of a DNA molecule. There are typically
  millions of fragments in a ReadGroup. A fragment has a name (QNAME in BAM
  spec), a length (TLEN in BAM spec), and an array of reads.
 * A *read* is a contiguous sequence of bases. There are typically only one or
@@ -29,7 +29,7 @@ ReadGroupSet >--< ReadGroup --< fragment --< read --< alignment --< linear/graph
  of a chimeric alignment.
 * A ReadAlignment object is a flattened representation of the bottom layers
  of this hierarchy. There's exactly one such object per *linear alignment* or
- *graph alignment*. The object contains alignment info, plus fragment and read
+ *graph alignment*. The object contains alignment info and read
  info for easy access.
 */
 protocol Reads {
@@ -208,6 +208,27 @@ record Fragment {
   /** The fragment ID. */
   string id;
 
+  /** The fragment name. Equivalent to QNAME (query template name) in SAM.*/
+  string fragmentName;
+
+  /**
+  The orientation and the distance between reads from the fragment are
+  consistent with the sequencing protocol (equivalent to SAM flag 0x2)
+  */
+  union { null, boolean } properPlacement = null;
+
+  /** The fragment is a PCR or optical duplicate (SAM flag 0x400) */
+  union { null, boolean } duplicateFragment = null;
+
+  /** The number of reads in the fragment (extension to SAM flag 0x1) */
+  union { null, int } numberReads = null;
+
+  /** The observed length of the fragment, equivalent to TLEN in SAM. */
+  union { null, int } fragmentLength = null;
+
+  /** The `ReadAlignment`s in the fragment
+  array<ReadAlignment> readAlignments = [];
+
 }
 
 /**
@@ -231,28 +252,10 @@ record ReadAlignment {
   */
   string readGroupId;
 
-  // fragment attributes
-  
+  // We preserve this so that a list of reads with data equivalent to a bam
+  // file may be generated in linear time
   /** The fragment ID that this ReadAlignment belongs to. */
   string fragmentId;
-
-  /** The fragment name. Equivalent to QNAME (query template name) in SAM.*/
-  string fragmentName;
-
-  /**
-  The orientation and the distance between reads from the fragment are
-  consistent with the sequencing protocol (equivalent to SAM flag 0x2)
-  */
-  union { null, boolean } properPlacement = null;
-
-  /** The fragment is a PCR or optical duplicate (SAM flag 0x400) */
-  union { null, boolean } duplicateFragment = null;
-
-  /** The number of reads in the fragment (extension to SAM flag 0x1) */
-  union { null, int } numberReads = null;
-
-  /** The observed length of the fragment, equivalent to TLEN in SAM. */
-  union { null, int } fragmentLength = null;
 
   // read attributes
 

--- a/src/main/resources/avro/reads.avdl
+++ b/src/main/resources/avro/reads.avdl
@@ -330,12 +330,6 @@ record ReadAlignment {
   array<int> alignedQuality = [];
 
   /**
-  The mapping of the primary alignment of the `(readNumber+1)%numberReads`
-  read in the fragment. It replaces mate position and mate strand in SAM.
-  */
-  union { null, Side } nextMatePosition = null;
-
-  /**
   A map of additional read alignment information.
   */
   map<array<string>> info = {};


### PR DESCRIPTION
I'll leave this here as a starting point for discussion. This reopens the can of worms from #212.
By keeping the fragmentId in the ReadAlignment, construction of a bam equivalent object should remain extremely simple.
