### PR TITLE
Removing CallSet as a first-class object; VCF merging and the N+1 problem

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -70,11 +70,12 @@ record SearchVariantsRequest {
   string variantSetId;
 
   /**
-  Only return variant calls which belong to call sets with these IDs.
+  Only return variant calls belonging to these columns.
   If an empty array, returns variants without any call objects.
   If null, returns all variant calls.
+  TODO: rename
   */
-  union { null, array<string> } callSetIds = null;
+  union { null, array<string> } columnHandles = null;
 
   /** Required. Only return variants on this reference. */
   string referenceName;
@@ -112,11 +113,10 @@ record SearchVariantsRequest {
 record SearchVariantsResponse {
   /**
   The list of matching variants.
-  If the `callSetId` field on the returned calls is not present,
-  the ordering of the call sets from a `SearchCallSetsRequest`
-  over the parent `VariantSet` is guaranteed to match the ordering
-  of the calls on each `Variant`. The number of results will also be
-  the same.
+  If the `columnHandle` field on the returned calls is not present, the
+  ordering of the columns from a `SearchVariantsRequest` over the parent
+  `VariantSet` is guaranteed to match the ordering of the calls on each
+  `Variant`. The number of results will also be the same.
   */
   array<org.ga4gh.models.Variant> variants = [];
 
@@ -146,69 +146,6 @@ Gets a `Variant` by ID.
 org.ga4gh.models.Variant getVariant(
   /**
   The ID of the `Variant`.
-  */
-  string id) throws GAException;
-
-/******************  /callsets/search  *********************/
-/** This request maps to the body of `POST /callsets/search` as JSON. */
-record SearchCallSetsRequest {
-  /**
-  The VariantSet to search.
-  */
-  string variantSetId;
-
-  /**
-  Only return call sets with this name (case-sensitive, exact match).
-  */
-  union { null, string } name = null;
-
-  // TODO: Add more ways to search by other metadata
-
-  /**
-  Specifies the maximum number of results to return in a single page.
-  If unspecified, a system default will be used.
-  */
-  union { null, int } pageSize = null;
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  To get the next page of results, set this parameter to the value of
-  `nextPageToken` from the previous response.
-  */
-  union { null, string } pageToken = null;
-}
-
-/** This is the response from `POST /callsets/search` expressed as JSON. */
-record SearchCallSetsResponse {
-  /** The list of matching call sets. */
-  array<org.ga4gh.models.CallSet> callSets = [];
-
-  /**
-  The continuation token, which is used to page through large result sets.
-  Provide this value in a subsequent request to return the next page of
-  results. This field will be empty if there aren't any additional results.
-  */
-  union { null, string } nextPageToken = null;
-}
-
-/**
-Gets a list of `CallSet` matching the search criteria.
-
-`POST /callsets/search` must accept a JSON version of `SearchCallSetsRequest`
-as the post body and will return a JSON version of `SearchCallSetsResponse`.
-*/
-SearchCallSetsResponse searchCallSets(
-  /** This request maps to the body of `POST /callsets/search` as JSON. */
-  SearchCallSetsRequest request) throws GAException;
-
-/****************  /callsets/{id}  *******************/
-/**
-Gets a `CallSet` by ID.
-`GET /callsets/{id}` will return a JSON version of `CallSet`.
-*/
-org.ga4gh.models.CallSet getCallSet(
-  /**
-  The ID of the `CallSet`.
   */
   string id) throws GAException;
 

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -41,7 +41,7 @@ record VariantSetMetadata {
 }
 
 /**
-`Variant` and `CallSet` both belong to a `VariantSet`.
+`Variant` belongs to a `VariantSet`.
 `VariantSet` belongs to a `Dataset`.
 The variant set is equivalent to a VCF file.
 */
@@ -58,43 +58,17 @@ record VariantSet {
   string referenceSetId;
 
   /**
+  Handles to the "columns" of the VariantSet, each unique at least within the
+  VariantSet.
+  TODO: rename this pending the outcome of other PRs.
+  */
+  array<string> columnHandles = [];
+
+  /**
   The metadata associated with this variant set. This is equivalent to
   the VCF header information not already presented in first class fields.
   */
   array<VariantSetMetadata> metadata = [];
-}
-
-/**
-A `CallSet` is a collection of variant calls for a particular sample.
-It belongs to a `VariantSet`. This is equivalent to one column in VCF.
-*/
-record CallSet {
-
-  /** The call set ID. */
-  string id;
-
-  /** The call set name. */
-  union { null, string } name = null;
-
-  /** The sample this call set's data was generated from. */
-  union { null, string } sampleId;
-
-  /** The IDs of the variant sets this call set has calls in. */
-  array<string> variantSetIds = [];
-
-  /** The date this call set was created in milliseconds from the epoch. */
-  union { null, long } created = null;
-
-  /**
-  The time at which this call set was last updated in
-  milliseconds from the epoch.
-  */
-  union { null, long } updated = null;
-
-  /**
-  A map of additional call set information.
-  */
-  map<array<string>> info = {};
 }
 
 /**
@@ -108,23 +82,14 @@ the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 record Call {
 
   /**
-  The name of the call set this variant call belongs to.
-  If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
-  the ordering of the calls on this `Variant`.
+  The handle of the column this variant call belongs to.
+  If this field is not present, the ordering of the columns from a
+  `SearchVariantsRequest` over this `VariantSet` is guaranteed to match the
+  ordering of the calls on this `Variant`.
   The number of results will also be the same.
+  TODO: rename
   */
-  union { null, string } callSetName = null;
-
-  /**
-  The ID of the call set this variant call belongs to.
-
-  If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
-  the ordering of the calls on this `Variant`.
-  The number of results will also be the same.
-  */
-  union { null, string} callSetId = null;
+  union { null, string } columnHandle = null;
 
   /**
   The genotype of this variant call.


### PR DESCRIPTION
(Background: @dglazer recently wrote a [nice recap](https://github.com/ga4gh/schemas/pull/391#issuecomment-134821662) of the conceptual model underlying the Reads+Variants API. This PR grew out of discussion in #383 and #391, and involves conceptual issues that have been aired previously #49 #73 #168, but perhaps not fully litigated in this group.)

The concept on trial in this PR is the CallSet, which represents a "column of genotype calls" in a VariantSet, roughly equivalent to one column of a multicolumnar VCF file. CallSets are first-class objects in our API, with their own 'created' and 'updated' timestamps, and optionally other metadata. This supports a mode of operations in which existing VariantSets can be merged together, such that the merged VariantSet composes several CallSets generated at different times and perhaps using different methods. Modeling this situation seems to be the main reason for CallSet to be a first-class object rather than constitutively a part of a single VariantSet.

Because our Variants schema adheres to the VCF data model, it inherits some fundamental difficulties with merging VCFs. First, there's distinguishing homozygous reference from no-call at variant sites not present in all CallSets. Second, it's difficult to construct a "convenient" representation of the merged VariantSet when there are multiple different overlapping variants in the CallSets. We'll elaborate on "convenient" below, but the result of these difficulties is that the generation of multicolumnar VariantSets is usually more complicated than the composition of CallSets contemplated above. There are often algorithmic steps involved that transform the inputs or supplement them with other data, such that the new VariantSet really consists of all-new CallSets generated together. This "N+1 problem" — the need to reprocess everything in some way when adding a new [analysis] sample to a study — is an outstanding challenge in the abstract VCF data model.

Now that stated, simple compositional merging of existing VariantSets — e.g. joining VCF rows by exact (POS,REF,ALT) — can be a useful operation in practice. That type of procedure handles common cases like biallelic SNVs well, and VCF data can be prepared in particular ways that help to marginalize other problematic cases (e.g. reducing to allelic primitives, splitting multiallelic sites into overlapping biallelic sites, and including all homozygous reference genotypes). The residual issues/limitations with VCF merging may then be quite tolerable, depending on the use case.
### The proposal

This pull request removes CallSet as a first-class API object. A column of calls becomes constitutively a part of one VariantSet and shares its metadata. API operations refer to columns by some "handle" string, unique at least within the VariantSet. This "handle" concept is a placeholder as other in-flight pull requests aim to ascribe additional meaning to them, upon which a different term such as "analysis sample" will be substituted.
### The prosecution
- Let's jettison CallSet because we don't need to provide a first-class abstraction mainly useful to model one rather simplistic way of merging VariantSets.
- This doesn't _prevent_ anyone from merging VariantSets however they like, creating new VariantSets with distinct columns.
- It diminishes a potential illusion that the Global Alliance already has a sound general solution for VCF merging or the N+1 problem.
- The CallSet concept has proven confusing to many of us, let alone outsiders, and removing it simplifies things. 
- We can add a CallSet-like object later, if/when we adopt a new model of genetic variation with easier merge semantics (which will probably require an effective rewrite of the Variants API anyway).
### The defense
- Let's keep our first-class CallSets because they're helpful to model VariantSet merging, a useful and commonly-practiced operation.
- The corner cases where simple VariantSet merging causes problems are tolerable for many use cases, and it's much easier and more scalable than alternatives.
- CallSet objects are more generally a useful place to stick any metadata applicable specifically to the (VariantSet, analysis sample) cross, regardless of how/when they were generated.
- Just finding a better name for CallSet would suffice to reduce confusion.
- Having first-class CallSets now will architecturally prepare implementations for future variation models with easier merge semantics.

<hr/>
### Appendix: how should a multicolumnar VariantSet look?

By "convenient", above, we mean a multicolumnar VariantSet would ideally present a "squared-off" matrix of genotypes, with non-overlapping variants, mutually-exclusive alleles, and the fewest possible missing entries. This is desirable for downstream analysts, because it's then straightforward to calculate population-genetic statistics, association tests, genotype posteriors, and partition functions. Those are much harder to formulate based on "ragged" genotypes, because of the need to meticulously account for the entanglement of overlapping variants and alleles. Indeed, beyond mere convenience, some propose that VCFs "[SHOULD NOT](https://www.ietf.org/rfc/rfc2119.txt)" contain overlapping variants [[1](https://github.com/ga4gh/schemas/issues/168#issuecomment-60795294),[2](https://github.com/ga4gh/schemas/issues/168#issuecomment-60789648)].

Current formal methods for finding the squared-off genotype matrix are not really "VCF merging" _per se_, but rather probabilistic algorithms relying on lower-level forms of input data. The most challenging aspect of these algorithms is that the matrix is generated jointly, modeling all observations simultaneously in each row, and possibly across rows. Observing the N+1th sample sometimes causes revisions to all previous N samples!

Short of formal joint genotyping, there are also _ad hoc_ VCF merging procedures that work harder to achieve "squareness" than (POS,REF,ALT) joining, e.g. by unifying multiallelic sites and rewriting genotypes when possible, and using auxiliary read coverage information to adjudicate ref/no-call. Still, these are also generating _new_ data rather than merely composing existing data.
