### PR TITLE
Changed referenceName to referenceId.

### DIFF
--- a/src/main/resources/avro/common.avdl
+++ b/src/main/resources/avro/common.avdl
@@ -22,9 +22,9 @@ represented by a `Reference` name, and a base number on that `Reference`
 */
 record Position {
   /**
-  The name of the `Reference` on which the `Position` is located.
+  The ID of the `Reference` on which the `Position` is located.
   */
-  string referenceName;
+  string referenceId;
 
   /**
   The 0-based offset from the start of the forward strand for that `Reference`.

--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -77,7 +77,7 @@ record SearchVariantsRequest {
   union { null, array<string> } callSetIds = null;
 
   /** Required. Only return variants on this reference. */
-  string referenceName;
+  string referenceId;
 
   /**
   Required. The beginning of the window (0-based, inclusive) for

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -196,9 +196,8 @@ record Variant {
 
   /**
   The reference on which this variant occurs.
-  (e.g. `chr20` or `X`)
   */
-  string referenceName;
+  string referenceId;
 
   /**
   The start position at which this variant occurs (0-based).


### PR DESCRIPTION
This PR follows on from recent discussions in #418, #417, #399, #403. There is a seemingly growing consensus that IDs should be used for all API linkage points, and names are more human-readable local identifiers which might be locally unique within a collection or not; see #417 for the discussion on this point.

Whether names are locally unique or not, I don't think they should be used as API object linkage. The Variants API currently uses `referenceName` to identify the Reference object within a given ReferenceSet that the variant is defined in terms of. This is inconsistent with other parts of the API.

The only argument that I can see in favour of using `referenceName` here rather than `referenceId` is that it's slightly more convenient for client side developers, since they can hard code the string  "1" (e.g.) instead of needing to lookup which reference object corresponds to this name. However, this only really applies to the case in which there's a well known ReferenceSet, with a small number of References. For most general applications, the client would have to look up the ReferenceSet to find the names of the contained references in any case, so it doesn't matter if we use `referenceName` or `referenceId`.

Using `referenceName` encourages poor programming practise, where we hard code the names of the chromosomes into code rather than looking them up. It is based on the idea of a small number of universally known, static references, which is something that will become less true over time, particularly when we think of graph references.
