### PR TITLE
replace CallSet id and name with label

### DIFF
--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -65,6 +65,11 @@ record VariantSet {
   the VCF header information not already presented in first class fields.
   */
   array<VariantSetMetadata> metadata = [];
+  
+  /**
+  The default CallMethod id for CallSets in this VariantSet.
+  */
+  union { null, string } methodId = null;
 }
 
 /**
@@ -73,31 +78,23 @@ It belongs to a `VariantSet`. This is equivalent to one column in VCF.
 */
 record CallSet {
 
-  /** The call set ID. */
-  string id;
-
-  /** The call set name. */
-  union { null, string } name = null;
+  /** 
+  The label for this CallSet.  User-defined, unique within its VariantSet.  
+  Required to satisfy identifier syntax [A-Za-z][A-Za-z0-9_]* 
+  */
+  string label;
 
   /** The sample this call set's data was generated from. */
-  union { null, string } sampleId;
+  union { null, string } sampleId = null;
+  
+  /** An id for a CallMethod with information about the calling process. */
+  union { null, string } methodId = null;
 
-  /** The IDs of the variant sets this call set has calls in. */
-  array<string> variantSetIds = [];
+  /** The ID of the variant set this call set has calls in. */
+  string variantSetId;
 
-  /** The date this call set was created in milliseconds from the epoch. */
+  /** The time this call set was created in milliseconds from the epoch. */
   union { null, long } created = null;
-
-  /**
-  The time at which this call set was last updated in
-  milliseconds from the epoch.
-  */
-  union { null, long } updated = null;
-
-  /**
-  A map of additional call set information.
-  */
-  map<array<string>> info = {};
 }
 
 /**
@@ -111,23 +108,13 @@ the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 record Call {
 
   /**
-  The name of the call set this variant call belongs to.
+  The label of the call set this variant call belongs to.
   If this field is not present, the ordering of the call sets from a
   `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
   the ordering of the calls on this `Variant`.
   The number of results will also be the same.
   */
-  union { null, string } callSetName = null;
-
-  /**
-  The ID of the call set this variant call belongs to.
-
-  If this field is not present, the ordering of the call sets from a
-  `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
-  the ordering of the calls on this `Variant`.
-  The number of results will also be the same.
-  */
-  union { null, string} callSetId = null;
+  union { null, string } callSetLabel = null;
 
   /**
   The genotype of this variant call.
@@ -215,7 +202,6 @@ record Variant {
   */
   long end;
 
-
   /**
   The reference bases for this variant. They start at the given start position.
   */
@@ -240,4 +226,11 @@ record Variant {
   array<Call> calls = [];
 }
 
+record CallMethod {
+  /** The id for this call method */
+  string id;
+  
+  /** A map of information about the calling method */
+  map<array<string>> info = {};
+}
 }


### PR DESCRIPTION
This replaces the id (server-owned) and name (user-owned) for a CallSet by a label (user-defined, subject to uniqueness and syntax constraints).  This allows user-meaningful labels for the equivalent of VCF columns, without semantic problems of clashes.

Also it moves the info map for a call set to a new CallMethod object, with a methodId in the call set, and a default one in the variant set.
This allows sharing of meta-information about the calling process and other aspects of call sets.

Other changes are that I made call-sets only belong to one variant set (why could they belong to many?) and removed the updated timestamp because currently we have no way to update.

The new concept is Label, which is a string of printable characters, unique within the scope of the variant set, possibly with restricted syntax e.g. [a-zA-Z][a-zA-Z0-9_]\* like programming language identifiers.  The aim is that this should be a reasonable thing for users to look at and use, e.g. to display as column headings, or use in queries.
This replaces both columnId, which is server-unique and not under user control, and name, which is user-defined and can’t be relied on to be unique.
We are OK to require the labels to be unique, because the scope is limited to the VariantSet, so long range clashes are not a problem.  The semantics of merging VariantSets can be specified as part of the merge operation - both options of maintaining uniqueness by adding suffixes if necessary or forcing merge when the labels coincide have merit in different circumstances.
Because the labels must be unique, they can be used as a key for retrieval of CallSet columns in the VariantSet.
Having them separate from the sampleId means that you can have two CallSet columns for the same sample in one VariantSet, which is nice to be able to compare call sets made in different ways from the same sample (e.g. Illumina versus CG, or different callers).
Having a methodId that references an external Method object, which contains an info map for metadata, allows columns to share the same information about how they were called.  We also add an optional methodId to the VariantSet itself, which would then act as a default for all its callsets, covering the standard case where all callsets are made the same way.

It is good for both sampleId and methodId to be optional, so that lightweight VariantSets can be made by importing VCF files or the equivalent, without having to create lots of other empty objects first.  We should not underestimate the importance of lightweight use of the object representation and API - a large amount of sequence data handling is done in small labs with LIMS that will autopopulate Sample objects, or in exploratory analysis, and we would like users not to have to manage unnecessary appendages.

I need to add changes to variantMethods to this pull request, but don't know how to just now in this web interface.
