### PR TITLE
Readgroups Endpoint

### DIFF
--- a/src/main/proto/ga4gh/read_service.proto
+++ b/src/main/proto/ga4gh/read_service.proto
@@ -107,22 +107,25 @@ message GetReadGroupSetRequest {
 message SearchReadGroupsRequest {
   // The dataset to search (required).
   string dataset_id = 1;
+  
+  // The read_group_set to search (optional).
+  string read_group_set_id = 2;
 
   // Only return read groups with this name (case-sensitive, exact match).
-  string name = 2;
+  string name = 3;
 
   //  Specifying the id of a BioSample record will return only readgroups
   //  with the given bioSampleId.
-  string bio_sample_id = 3;
+  string bio_sample_id = 4;
 
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.
-  int32 page_size = 4;
+  int32 page_size = 5;
 
   // The continuation token, which is used to page through large result sets.
   // To get the next page of results, set this parameter to the value of
   // `next_page_token` from the previous response.
-  string page_token = 5;
+  string page_token = 6;
 }
 
 // This is the response from `POST /readgroups/search` expressed as JSON.

--- a/src/main/proto/ga4gh/read_service.proto
+++ b/src/main/proto/ga4gh/read_service.proto
@@ -9,11 +9,19 @@ service ReadService {
   //
   // `POST /readgroupsets/search` must accept a JSON version of
   // `SearchReadGroupSetsRequest` as the post body and will return a JSON
-  // version of `SearchReadGroupSetsResponse`. Only readgroups that
-  // match an optionally supplied bioSampleId will be included in the
-  // response.
+  // version of `SearchReadGroupSetsResponse`.
   rpc SearchReadGroupSets(SearchReadGroupSetsRequest)
       returns (SearchReadGroupSetsResponse);
+
+  // Gets a list of `ReadGroups` matching the search criteria.
+  //
+  // `POST /readgroups/search` must accept a JSON version of
+  // `SearchReadGroupsRequest` as the post body and will return a JSON
+  // version of `SearchReadGroupsResponse`.
+  rpc SearchReadGroups(SearchReadGroupsRequest)
+      returns (SearchReadGroupsResponse);
+  
+  rpc GetReadGroup(GetReadGroup) returns (ReadGroup);
 
   // Gets a `ReadGroupSet` by ID.
   //
@@ -89,6 +97,49 @@ message SearchReadGroupSetsResponse {
 message GetReadGroupSetRequest {
   // The ID of the `ReadGroupSet` to be retrieved.
   string read_group_set_id = 1;
+}
+
+// ******************  /readgroups  *********************/
+
+// This request maps to the body of `POST /readgroups/search` as JSON.
+
+
+message SearchReadGroupsRequest {
+  // The dataset to search.
+  string dataset_id = 1;
+
+  // Only return read groups with this name (case-sensitive, exact match).
+  string name = 2;
+
+  //  Specifying the id of a BioSample record will return only readgroups
+  //  with the given bioSampleId.
+  string bio_sample_id = 3;
+
+  // Specifies the maximum number of results to return in a single page.
+  // If unspecified, a system default will be used.
+  int32 page_size = 4;
+
+  // The continuation token, which is used to page through large result sets.
+  // To get the next page of results, set this parameter to the value of
+  // `next_page_token` from the previous response.
+  string page_token = 5;
+}
+
+// This is the response from `POST /readgroups/search` expressed as JSON.
+message SearchReadGroupsResponse {
+  // The list of matching read groups.
+  repeated ReadGroupSet read_groups = 1;
+
+  // The continuation token, which is used to page through large result sets.
+  // Provide this value in a subsequent request to return the next page of
+  // results. This field will be empty if there aren't any additional results.
+  string next_page_token = 2;
+}
+
+// This request maps to the URL `GET /readgroups/{read_group_id}`.
+message GetReadGroupRequest {
+  // The ID of the `ReadGroup` to be retrieved.
+  string read_group_id = 1;
 }
 
 // ******************  /reads  *********************

--- a/src/main/proto/ga4gh/read_service.proto
+++ b/src/main/proto/ga4gh/read_service.proto
@@ -74,12 +74,12 @@ message SearchReadGroupSetsRequest {
 
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.
-  int32 page_size = 3;
+  int32 page_size = 4;
 
   // The continuation token, which is used to page through large result sets.
   // To get the next page of results, set this parameter to the value of
   // `next_page_token` from the previous response.
-  string page_token = 4;
+  string page_token = 5;
 }
 
 // This is the response from `POST /readgroupsets/search` expressed as JSON.
@@ -105,27 +105,24 @@ message GetReadGroupSetRequest {
 
 
 message SearchReadGroupsRequest {
-  // The dataset to search.
+  // The dataset to search (required).
   string dataset_id = 1;
-  
-  // Only return readgroups within the provided read group set ID.
-  string read_group_set_id = 2;
 
   // Only return read groups with this name (case-sensitive, exact match).
-  string name = 3;
+  string name = 2;
 
   //  Specifying the id of a BioSample record will return only readgroups
   //  with the given bioSampleId.
-  string bio_sample_id = 4;
+  string bio_sample_id = 3;
 
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.
-  int32 page_size = 5;
+  int32 page_size = 4;
 
   // The continuation token, which is used to page through large result sets.
   // To get the next page of results, set this parameter to the value of
   // `next_page_token` from the previous response.
-  string page_token = 6;
+  string page_token = 5;
 }
 
 // This is the response from `POST /readgroups/search` expressed as JSON.

--- a/src/main/proto/ga4gh/read_service.proto
+++ b/src/main/proto/ga4gh/read_service.proto
@@ -13,7 +13,7 @@ service ReadService {
   rpc SearchReadGroupSets(SearchReadGroupSetsRequest)
       returns (SearchReadGroupSetsResponse);
 
-  // Gets a list of `ReadGroups` matching the search criteria.
+  // Gets a list of `ReadGroup` matching the search criteria.
   //
   // `POST /readgroups/search` must accept a JSON version of
   // `SearchReadGroupsRequest` as the post body and will return a JSON
@@ -21,7 +21,11 @@ service ReadService {
   rpc SearchReadGroups(SearchReadGroupsRequest)
       returns (SearchReadGroupsResponse);
   
-  rpc GetReadGroup(GetReadGroup) returns (ReadGroup);
+  // Gets a `ReadGroup` by ID.
+  //
+  // `GET /readgroups/{read_group_id}` will return a JSON version of
+  // `ReadGroup`.
+  rpc GetReadGroup(GetReadGroupRequest) returns (ReadGroup);
 
   // Gets a `ReadGroupSet` by ID.
   //
@@ -68,18 +72,14 @@ message SearchReadGroupSetsRequest {
   // Only return read group sets with this name (case-sensitive, exact match).
   string name = 2;
 
-  //  Specifying the id of a BioSample record will return only readgroups
-  //  with the given bioSampleId.
-  string bio_sample_id = 3;
-
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.
-  int32 page_size = 4;
+  int32 page_size = 3;
 
   // The continuation token, which is used to page through large result sets.
   // To get the next page of results, set this parameter to the value of
   // `next_page_token` from the previous response.
-  string page_token = 5;
+  string page_token = 4;
 }
 
 // This is the response from `POST /readgroupsets/search` expressed as JSON.
@@ -107,22 +107,25 @@ message GetReadGroupSetRequest {
 message SearchReadGroupsRequest {
   // The dataset to search.
   string dataset_id = 1;
+  
+  // Only return readgroups within the provided read group set ID.
+  string read_group_set_id = 2;
 
   // Only return read groups with this name (case-sensitive, exact match).
-  string name = 2;
+  string name = 3;
 
   //  Specifying the id of a BioSample record will return only readgroups
   //  with the given bioSampleId.
-  string bio_sample_id = 3;
+  string bio_sample_id = 4;
 
   // Specifies the maximum number of results to return in a single page.
   // If unspecified, a system default will be used.
-  int32 page_size = 4;
+  int32 page_size = 5;
 
   // The continuation token, which is used to page through large result sets.
   // To get the next page of results, set this parameter to the value of
   // `next_page_token` from the previous response.
-  string page_token = 5;
+  string page_token = 6;
 }
 
 // This is the response from `POST /readgroups/search` expressed as JSON.

--- a/src/main/proto/ga4gh/reads.proto
+++ b/src/main/proto/ga4gh/reads.proto
@@ -34,48 +34,48 @@ message ReadGroup {
   string dataset_id = 2;
   
   // The ID of the read group set this read group belongs to.
-  string read_group_set_id = 3;
+  string read_group_set_id = 15;
 
   // The read group name.
-  string name = 4;
+  string name = 3;
 
   // The read group description.
-  string description = 5;
+  string description = 4;
 
   // A name for the sample this read group's data were generated from.
   // This field contains an arbitrary string, typically
   // corresponding to the SM tag in a BAM file.
-  string sample_name = 6;
+  string sample_name = 5;
   
   // The BioSample this read group's data was generated from.
-  string bio_sample_id = 7;
+  string bio_sample_id = 6;
 
   // The experiment used to generate this read group.
-  Experiment experiment = 8;
+  Experiment experiment = 7;
 
   // The predicted insert size of this read group.
-  int32 predicted_insert_size = 9;
+  int32 predicted_insert_size = 8;
 
   // The time at which this read group was created in milliseconds from the
   // epoch.
-  int64 created = 10;
+  int64 created = 9;
 
   // The time at which this read group was last updated in milliseconds
   // from the epoch.
-  int64 updated = 11;
+  int64 updated = 10;
 
   // Statistical data on reads in this read group.
-  ReadStats stats = 12;
+  ReadStats stats = 11;
 
   // Program can be used to track the provenance of how read data was generated.
   repeated Program programs = 12;
 
   // The ID of the reference set to which the reads in this read group are
   // aligned. Required if there are any read alignments.
-  string reference_set_id = 14;
+  string reference_set_id = 13;
 
   // A map of additional read group information.
-  map<string, google.protobuf.ListValue> info = 15;
+  map<string, google.protobuf.ListValue> info = 14;
 }
 
 // A ReadGroupSet is a logical collection of ReadGroups. Typically one
@@ -94,6 +94,9 @@ message ReadGroupSet {
 
   // Statistical data on reads in this read group set.
   ReadStats stats = 4;
+  
+  // IDs of the Read Groups in this ReadGroupSet
+  repeated string read_group_ids = 6;
 }
 
 // A linear alignment describes the alignment of a read to a Reference, using a

--- a/src/main/proto/ga4gh/reads.proto
+++ b/src/main/proto/ga4gh/reads.proto
@@ -32,50 +32,56 @@ message ReadGroup {
 
   // The ID of the dataset this read group belongs to.
   string dataset_id = 2;
+  
+  // The ID of the read group set this read group belongs to.
+  string read_group_set_id = 3;
 
   // The read group name.
-  string name = 3;
+  string name = 4;
 
   // The read group description.
-  string description = 4;
+  string description = 5;
 
   // A name for the sample this read group's data were generated from.
   // This field contains an arbitrary string, typically
   // corresponding to the SM tag in a BAM file.
-  string sample_name = 5;
+  string sample_name = 6;
   
   // The BioSample this read group's data was generated from.
-  string bio_sample_id = 6;
+  string bio_sample_id = 7;
 
   // The experiment used to generate this read group.
-  Experiment experiment = 7;
+  Experiment experiment = 8;
 
   // The predicted insert size of this read group.
-  int32 predicted_insert_size = 8;
+  int32 predicted_insert_size = 9;
 
   // The time at which this read group was created in milliseconds from the
   // epoch.
-  int64 created = 9;
+  int64 created = 10;
 
   // The time at which this read group was last updated in milliseconds
   // from the epoch.
-  int64 updated = 10;
+  int64 updated = 11;
 
   // Statistical data on reads in this read group.
-  ReadStats stats = 11;
+  ReadStats stats = 12;
 
+  // Program can be used to track the provenance of how read data was generated.
   repeated Program programs = 12;
 
   // The ID of the reference set to which the reads in this read group are
   // aligned. Required if there are any read alignments.
-  string reference_set_id = 13;
+  string reference_set_id = 14;
 
   // A map of additional read group information.
-  map<string, google.protobuf.ListValue> info = 14;
+  map<string, google.protobuf.ListValue> info = 15;
 }
 
 // A ReadGroupSet is a logical collection of ReadGroups. Typically one
 // ReadGroupSet represents all the reads from one experimental sample.
+// All read groups require that all readgroups in the set are mapped to
+// the same referenceSet.
 message ReadGroupSet {
   // The read group set ID.
   string id = 1;
@@ -88,12 +94,6 @@ message ReadGroupSet {
 
   // Statistical data on reads in this read group set.
   ReadStats stats = 4;
-
-  // The read groups in this set.
-  repeated ReadGroup read_groups = 5;
-
-  // NB: we require that all readgroups in the set are mapped to the same
-  // referenceSet.
 }
 
 // A linear alignment describes the alignment of a read to a Reference, using a
@@ -110,8 +110,7 @@ message LinearAlignment {
   int32 mapping_quality = 2;
 
   // Represents the local alignment of this sequence (alignment matches, indels,
-  // etc)
-  // versus the reference.
+  // etc) versus the reference.
   repeated CigarUnit cigar = 3;
 }
 


### PR DESCRIPTION
The access patterns for the reads API would be improved by adding a read groups endpoint (#650). Currently the readgroupset endpoint returns a repeated list of readgroups matching the search criteria. This is confusing because the readgroupset record is modified at query time.

This PR adds the `/readgroups/search` endpoint, which exposes the available read groups using familiar strict matching on name, `bio_sample_id`, `dataset_id`, and `read_group_set_id`. Read group set messages no longer contain the list of readgroups since they can be retrieved using `readgroups/<read_group_id>`. This simplifies the read group set endpoint by moving the `bio_sample_id` filter to the appropriate entity, `ReadGroup`, as a single read group set might contain reads for many samples.
