### PR TITLE
Calls search endpoint

### DIFF
--- a/src/main/proto/ga4gh/variant_service.proto
+++ b/src/main/proto/ga4gh/variant_service.proto
@@ -133,6 +133,46 @@ message GetVariantRequest {
   string variant_id = 1;
 }
 
+// ******************  /calls  *********************
+// This request maps to the body of `POST /calls/search` as JSON.
+message SearchCallsRequest {
+  // The VariantSet to search.
+  string variant_set_id = 1;
+
+  // Only return calls with this Call Set ID.
+  string call_set_id = 2;
+  
+  // Only returns calls for this variant ID.
+  string variant_id = 3;
+
+  // Specifies the maximum number of results to return in a single page.
+  // If unspecified, a system default will be used.
+  int32 page_size = 4;
+
+  // The continuation token, which is used to page through large result sets.
+  // To get the next page of results, set this parameter to the value of
+  // `next_page_token` from the previous response.
+  string page_token = 5;
+}
+
+// This is the response from `POST /calls/search` expressed as JSON.
+message SearchCallsResponse {
+  // The list of matching calls.
+  repeated Call calls = 1;
+
+  // The continuation token, which is used to page through large result sets.
+  // Provide this value in a subsequent request to return the next page of
+  // results. This field will be empty if there aren't any additional results.
+  string next_page_token = 2;
+}
+
+// This request maps to the URL `GET /calls/{id}`.
+message GetCallRequest {
+  // The ID of the `Call` to be retrieved.
+  string call_id = 1;
+}
+
+
 // ******************  /callsets  *********************
 // This request maps to the body of `POST /callsets/search` as JSON.
 message SearchCallSetsRequest {

--- a/src/main/proto/ga4gh/variant_service.proto
+++ b/src/main/proto/ga4gh/variant_service.proto
@@ -136,13 +136,13 @@ message GetVariantRequest {
 // ******************  /calls  *********************
 // This request maps to the body of `POST /calls/search` as JSON.
 message SearchCallsRequest {
-  // The VariantSet to search.
+  // Only returns calls from the provided variant set (required).
   string variant_set_id = 1;
 
-  // Only return calls with this Call Set ID.
+  // If specified, only return calls with this Call Set ID.
   string call_set_id = 2;
   
-  // Only returns calls for this variant ID.
+  // If specified, only returns calls for this variant ID.
   string variant_id = 3;
 
   // Specifies the maximum number of results to return in a single page.

--- a/src/main/proto/ga4gh/variant_service.proto
+++ b/src/main/proto/ga4gh/variant_service.proto
@@ -83,10 +83,6 @@ message SearchVariantsRequest {
   // The `VariantSet` to search.
   string variant_set_id = 1;
 
-  // Only return variant calls which belong to call sets with these IDs.
-  // If unspecified, return all variants and no variant call objects.
-  repeated string call_set_ids = 2;
-
   // Required. Only return variants on this reference.
   string reference_name = 3;
 

--- a/src/main/proto/ga4gh/variants.proto
+++ b/src/main/proto/ga4gh/variants.proto
@@ -92,6 +92,9 @@ message CallSet {
 // and phasing. For example, a call might assign a probability of 0.32 to
 // the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 message Call {
+  // The call ID.
+  string id = 7;
+  
   // The name of the call set this variant call belongs to.
   // If this field is not present, the ordering of the call sets from a
   // `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
@@ -107,6 +110,9 @@ message Call {
   // The number of results will also be the same.
   string call_set_id = 2;
 
+  // The ID of the variant this call is made against.
+  string variant_id = 8;
+  
   // The genotype of this variant call.
   //
   // A 0 value represents the reference allele of the associated `Variant`. Any

--- a/src/main/proto/ga4gh/variants.proto
+++ b/src/main/proto/ga4gh/variants.proto
@@ -92,9 +92,6 @@ message CallSet {
 // and phasing. For example, a call might assign a probability of 0.32 to
 // the occurrence of a SNP named rs1234 in a call set with the name NA12345.
 message Call {
-  // The call ID.
-  string id = 7;
-  
   // The name of the call set this variant call belongs to.
   // If this field is not present, the ordering of the call sets from a
   // `SearchCallSetsRequest` over this `VariantSet` is guaranteed to match
@@ -109,13 +106,10 @@ message Call {
   // the ordering of the calls on this `Variant`.
   // The number of results will also be the same.
   string call_set_id = 2;
+  
+  // ID of the variant this call was made against.
+  string variant_id = 7;
 
-  // The ID of the variant this call is made against.
-  string variant_id = 8;
-  
-  // The ID of the variant set this call is a member of.
-  string variant_set_id = 9;
-  
   // The genotype of this variant call.
   //
   // A 0 value represents the reference allele of the associated `Variant`. Any
@@ -193,9 +187,4 @@ message Variant {
 
   // A map of additional variant information.
   map<string, google.protobuf.ListValue> info = 11;
-
-  // The variant calls for this particular variant. Each one represents the
-  // determination of genotype with respect to this variant. `Call`s in this
-  // array are implicitly associated with this `Variant`.
-  repeated Call calls = 12;
 }

--- a/src/main/proto/ga4gh/variants.proto
+++ b/src/main/proto/ga4gh/variants.proto
@@ -113,6 +113,9 @@ message Call {
   // The ID of the variant this call is made against.
   string variant_id = 8;
   
+  // The ID of the variant set this call is a member of.
+  string variant_set_id = 9;
+  
   // The genotype of this variant call.
   //
   // A 0 value represents the reference allele of the associated `Variant`. Any


### PR DESCRIPTION
This PR enables variant call data to be queried directly. Currently, call data are only made available in the variant message itself, which makes large sample sets difficult to work with. By enabling a separate endpoint for querying call data we can greatly improve common access patterns without disturbing the existing method.

The endpoint, `calls/search` receives a SearchCallsRequest, in which one provides a `variant_set_id`, `call_set_id`, or `variant_id`. This allows pages of Calls to be returned matching the search request as opposed to in a variant message. To carry out these requests and to support the GetCallSet request `variant_id` and `id` have been added to the `Call` message.

The existing method of accessing call data is left in place, however, I believe in general this practice of modifying messages at query time to be problematic. It leads to the situation where you have one identifier that could describe two unique returned messages. If this access pattern proves to serve for the same existing use cases we ought to deprecate placing calls in a variant message. For previous discussion on callsets see https://github.com/ga4gh/schemas/issues/583.
