### PR TITLE
Search references by name

### DIFF
--- a/src/main/proto/ga4gh/reference_service.proto
+++ b/src/main/proto/ga4gh/reference_service.proto
@@ -89,6 +89,10 @@ message GetReferenceSetRequest {
 message SearchReferencesRequest {
   // The `ReferenceSet` to search.
   string reference_set_id = 1;
+  
+  // If specified, return references with this name (case-sensitive,
+  // exact match).
+  string name = 6;
 
   // If specified, return the references for which the
   // `md5checksum` matches this string (case-sensitive, exact match).


### PR DESCRIPTION
A common use case of the references API is to find `reference_id` for building a SearchReadsRequest. This PR adds the ability to search references by their name.
