### PR TITLE
Variant annotation update (transcript effects endpoint)

### DIFF
--- a/src/main/proto/ga4gh/allele_annotation_service.proto
+++ b/src/main/proto/ga4gh/allele_annotation_service.proto
@@ -55,7 +55,20 @@ service AlleleAnnotationService {
         get: "/v0.6.0a8/variantannotationset/{variant_annotation_set_id}"
       };
     };
+  // Returns a list of transcript effects.
+  //
+  // `POST /transcripteffects/search` must accept a JSON version of
+  // `SearchTranscriptEffectsRequest` as the post body and will return a
+  // JSON version of `SearchTranscriptEffectsResponse`.
+  rpc SearchTranscriptEffects(SearchTranscriptEffectsRequest)
+      returns (SearchTranscriptEffectsResponse);
 
+  // Gets a `Transcript Effect` by ID.
+  //
+  // `GET /transcripteffects/{transcript_effect_id}` will return a JSON
+  // version of `TranscriptEffect`.
+  rpc GetTranscriptEffect(GetTranscriptEffectRequest)
+      returns (TranscriptEffect);
 }
 
 /******************  /variantannotations  *********************/
@@ -64,15 +77,19 @@ message SearchVariantAnnotationsRequest {
   // Required. The ID of the variant annotation set to search over.
   string variant_annotation_set_id = 1;
 
+  // If a variant_id is provided, only return annotations for that variant.
+  // Either a variant_id or range is required.
+  string variant_id = 9;
+  
   // Only return variants with reference alleles on the reference with this
-  // name. One of this field or `reference_id` is required.
+  // name. One of this field or `reference_id` is required if specifying a range.
   string reference_name = 2;
 
   // Only return variants with reference alleles on the reference with this
-  // ID. One of this field or `reference_name` is required.
+  // ID. One of this field or `reference_name` is required if specifying a range.
   string reference_id = 3;
 
-  // Required if reference_name or reference_id supplied. The beginning of the
+  // Required if specifying a range. The beginning of the
   // window (0-based, inclusive) for which variants with overlapping reference
   // alleles should be returned. Genomic positions are non-negative integers
   // less than reference length. Requests spanning the join of circular
@@ -80,30 +97,14 @@ message SearchVariantAnnotationsRequest {
   // (position 0).
   int64 start = 4;
 
-  // Required if reference_name or reference_id supplied. The end of the window
+  // Required if specifying a range. The end of the window
   // (0-based, exclusive) for which variants with overlapping reference
   // alleles should be returned.
   int64 end = 5;
-
-  // This section will be re-instated when features are available in the API
-  //
-  // Only return variant annotations for any of these features.
-  // Features may include specific transcripts or genes. A search by gene will
-  // return information for all transcripts associated with the gene in the
-  // variant annotation set.
-  // This or a location (referenceName/referenceId plus optional start and end)
-  // must be supplied.
-  // If empty, return all variant annotations in specified window.
-  // repeated string feature_ids;
-
-  // This filter allows variant, transcript combinations to be extracted by
-  // effect type(s). Only return variant annotations including any of these
-  // effects and only return transcript effects including any of these
-  // effects. Exact matching across all fields of the Sequence Ontology
-  // OntologyTerm is required. (A transcript effect may have multiple SO
-  // effects which will all be reported.) If empty, return all variant
-  // annotations.
-  repeated OntologyTerm effects = 6;
+  
+  // Only return variants with an allele frequency annotation over this value.
+  // Return all variants by default.
+  double frequency_threshold = 10;
 
   // Specifies the maximum number of results to return in a single page. If
   // unspecified, a system default will be used.
@@ -160,4 +161,82 @@ message SearchVariantAnnotationSetsResponse {
 message GetVariantAnnotationSetRequest {
   // The ID of the `VariantAnnotationSet` to be retrieved.
   string variant_annotation_set_id = 1;
+}
+
+/******************  /transcripteffects  *********************/
+// This request maps to the body of `POST /transcripteffects/search` as
+// JSON.
+message SearchTranscriptEffectsRequest {
+  // Required. The `VariantAnnotationSet` to search.
+  string variant_annotation_set_id = 1;
+  
+  // If a variant_annotation_id is provided only return transcript effects
+  // from this annotation.
+  // Either variant_annotation_id feature_id, or range is required.
+  string variant_annotation_id = 2;
+
+  // Only return variants with reference alleles on the reference with this
+  // name. One of this field or `reference_id` is required if specifying a range.
+  string reference_name = 3;
+
+  // Only return variants with reference alleles on the reference with this
+  // ID. One of this field or `reference_name` is required if specifying a range.
+  string reference_id = 4;
+
+  // Required if specifying a range. The beginning of the
+  // window (0-based, inclusive) for which variants with overlapping reference
+  // alleles should be returned. Genomic positions are non-negative integers
+  // less than reference length. Requests spanning the join of circular
+  // genomes are represented as two requests one on each side of the join
+  // (position 0).
+  int64 start = 5;
+
+  // Required if specifying a range. The end of the window
+  // (0-based, exclusive) for which variants with overlapping reference
+  // alleles should be returned.
+  int64 end = 6;
+  
+  // Only return transcript effects for any of these features.
+  // Features may include specific transcripts or genes. A search by gene will
+  // return information for all transcripts associated with the gene in the
+  // variant annotation set.
+  // This, a range, or feature ID are required.
+  // If empty, return all variant annotations in specified window.
+  repeated string feature_ids = 7;
+  
+  // Only return transcript effects including any of these
+  // effects. Exact matching across all fields of the Sequence Ontology
+  // OntologyTerm is required. (A transcript effect may have multiple SO
+  // effects which will all be reported.) If empty, transcript effects.
+  repeated OntologyTerm effects = 8;
+  
+  // Only return transcript effects with these alternate bases.
+  string alternate_bases = 9;
+
+  // Specifies the maximum number of results to return in a single page. If
+  // unspecified, a system default will be used.
+  int32 page_size = 10;
+
+  // The continuation token, which is used to page through large result sets.
+  // To get the next page of results, set this parameter to the value of
+  // `next_page_token` from the previous response.
+  string page_token = 11;
+}
+
+// This is the response from `POST /transcripteffects/search` expressed as
+// JSON.
+message SearchTranscriptEffectsResponse {
+  // The list of matching variant annotation sets.
+  repeated TranscriptEffect transcript_effects = 1;
+
+  // The continuation token, which is used to page through large result sets.
+  // Provide this value in a subsequent request to return the next page of
+  // results. This field will be empty if there aren't any additional results.
+  string next_page_token = 2;
+}
+
+// This request maps to the URL `GET /transcripteffects/{id}`.
+message GetTranscriptEffectRequest {
+  // The ID of the `TranscriptEffect` to be retrieved.
+  string transcript_effect_id = 1;
 }

--- a/src/main/proto/ga4gh/allele_annotation_service.proto
+++ b/src/main/proto/ga4gh/allele_annotation_service.proto
@@ -104,7 +104,11 @@ message SearchVariantAnnotationsRequest {
   
   // Only return variants with an allele frequency annotation over this value.
   // Return all variants by default.
-  double frequency_threshold = 10;
+  double minimum_frequency = 10;
+  
+  // Only return variants with an allele frequency annotation under this value.
+  // Return all variants by default.
+  double maximum_frequency = 11;
 
   // Specifies the maximum number of results to return in a single page. If
   // unspecified, a system default will be used.

--- a/src/main/proto/ga4gh/allele_annotation_service.proto
+++ b/src/main/proto/ga4gh/allele_annotation_service.proto
@@ -55,20 +55,30 @@ service AlleleAnnotationService {
         get: "/v0.6.0a8/variantannotationset/{variant_annotation_set_id}"
       };
     };
+
   // Returns a list of transcript effects.
   //
   // `POST /transcripteffects/search` must accept a JSON version of
   // `SearchTranscriptEffectsRequest` as the post body and will return a
   // JSON version of `SearchTranscriptEffectsResponse`.
   rpc SearchTranscriptEffects(SearchTranscriptEffectsRequest)
-      returns (SearchTranscriptEffectsResponse);
+      returns (SearchTranscriptEffectsResponse) {
+      option (google.api.http) = {
+        post: "/v0.6.0a8/transcripteffects/search"
+        body: "*"
+      };
+    };
 
   // Gets a `Transcript Effect` by ID.
   //
   // `GET /transcripteffects/{transcript_effect_id}` will return a JSON
   // version of `TranscriptEffect`.
   rpc GetTranscriptEffect(GetTranscriptEffectRequest)
-      returns (TranscriptEffect);
+      returns (TranscriptEffect) {
+      option (google.api.http) = {
+        get: "/v0.6.0a8/transcripteffects/{transcript_effect_id}"
+      };
+    };
 }
 
 /******************  /variantannotations  *********************/

--- a/src/main/proto/ga4gh/allele_annotations.proto
+++ b/src/main/proto/ga4gh/allele_annotations.proto
@@ -91,6 +91,12 @@ message TranscriptEffect {
   //  The ID of the transcript effect record
   string id = 1;
 
+  // The ID of the variant annotation this transcript effect belongs to.
+  string variant_annotation_id = 11;
+
+  // The ID of the variant this transcript effect's annotation belongs to.
+  string variant_id = 12;
+
   // The id of the transcript feature the annotation is relative to.
   // TODO: derive unique id from digest of data [location, allele, transcript?]
   string feature_id = 2;
@@ -135,10 +141,9 @@ message VariantAnnotation {
 
   // The time at which this record was created, in ISO 8601 format.
   string created = 4;
-
-  // The transcript effect annotation for the alleles of this variant. Each
-  // one represents the effect of a single allele on a single transcript.
-  repeated TranscriptEffect transcript_effects = 5;
+  
+  // The allele frequency provided by the annotation.
+  double allele_frequency = 7;
 
   // Additional annotation data in key-value pairs.
   map<string, google.protobuf.ListValue> info = 6;


### PR DESCRIPTION
The current variant annotation message structure faces an issue seen in other parts of the API (readgroupsets, variants). Messages returned from a search request may be modified during a query, causing the same identifier to point to two unique documents. This can cause problems in interchange. It also creates a complex nested document that can be difficult to work with in practice.

To solve this, another endpoint has been added for filtering transcript effects. This allows transcript effects to be filtered and operated on directly, as opposed to through the modification of Variant Annotation messages at query time. It also provides a more natural query interface by separating concerns from the `SearchVariantAnnotationsRequest`.

Another problem facing the Variant Annotation protocol was the difficulty in finding an annotation for a given variant. It isn't possible to directly get an annotation for a given variant, which has caused clients to have to search for similar ranges for a given variant in an annotation set. The addition of the `variant_id` to the `SearchVariantAnnotationsRequest` makes it possible to find annotations directly, when a `variant_id` is provided the range is ignored.

By request from the VATT, filtering annotations by allele frequency has been added. This was done by adding an `allele_frequency` field to the `VariantAnnotation` message and a `frequency_threshold` to the `SearchVariantAnnotationsRequest`. @reece @sarahhunt @kusdhill
- Search transcript effects directly (`/transcripteffects/search`)
- Filter variant annotations by `allele_frequency`
- Search variant annotations by variant ID
