### PR TITLE
Switch protobuf version to 3.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ install:
     - python setup.py install
 cache:
     directories:
-    - /tmp/proto3.1.0
+    - /tmp/proto3.2.0
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install graphviz
-    - bash tools/travis-install-protoc.sh 3.1.0
-    - export PATH=/tmp/proto3.1.0/bin:$PATH
+    - bash tools/travis-install-protoc.sh 3.2.0
+    - export PATH=/tmp/proto3.2.0/bin:$PATH
     - pip install -r python/dev-requirements.txt -c python/constraints.txt
 script:
     - make docs

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,4 +4,4 @@
 # These requirements are read directly into setup.py, so specify them
 # in the order that they should be in in setup.py
 ga4gh-common==0.0.7
-protobuf==3.1.0.post1
+protobuf==3.2.0


### PR DESCRIPTION
Bumps protobuf version to 3.2.0, which means C++ implementation on Linux and so faster/reduced memory usage. Addresses issue ga4gh/ga4gh-server#1623