### PR TITLE
remove reference to Avro

### DIFF
--- a/doc/source/appendix/proto_intro.rst
+++ b/doc/source/appendix/proto_intro.rst
@@ -4,8 +4,6 @@
 Google Protocol Buffers
 ***********************
 
-Apache Avro is a data serialization ecosystem, comparable to Google's Protocol Buffers.
-
 -------------------------------------------------------
 What does the GA4GH web API take from Protocol Buffers?
 -------------------------------------------------------


### PR DESCRIPTION
It seems that avro is no longer used, so this reference didn't really make sense.